### PR TITLE
Major improvements to PAM

### DIFF
--- a/partly_adequate_mapvote/lua/pam/server/extensions/custom_round_counter.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/custom_round_counter.lua
@@ -4,24 +4,20 @@ PAM_EXTENSION.name = name
 PAM_EXTENSION.enabled = false
 
 local setting_namespace = PAM.setting_namespace:AddChild(name)
-local round_limit = setting_namespace:AddSetting("round_limit", pacoman.TYPE_INTEGER, 6, "Determines how many rounds need to be played before a vote starts.")
+PAM_EXTENSION.round_limit = setting_namespace:AddSetting("round_limit", pacoman.TYPE_INTEGER, 6, "Determines how many rounds need to be played before a vote starts.")
 
 local custom_round_counter = 0;
 
 function PAM_EXTENSION:OnRoundEnded()
 	PAM.extension_handler.RunEvent("SetRoundCounter", custom_round_counter + 1)
 
-	if custom_round_counter >= round_limit:GetActiveValue() then
+	if custom_round_counter >= self.round_limit:GetActiveValue() then
 		PAM.Start()
 	end
 end
 
 function PAM_EXTENSION:GetRoundCounter()
 	return custom_round_counter
-end
-
-function PAM_EXTENSION:GetRoundLimit()
-	return round_limit:GetActiveValue()
 end
 
 function PAM_EXTENSION:SetRoundCounter(value)

--- a/partly_adequate_mapvote/lua/pam/server/extensions/custom_round_counter.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/custom_round_counter.lua
@@ -20,6 +20,10 @@ function PAM_EXTENSION:GetRoundCounter()
 	return custom_round_counter
 end
 
+function PAM_EXTENSION:GetRoundLimit()
+	return round_limit:GetActiveValue()
+end
+
 function PAM_EXTENSION:SetRoundCounter(value)
 	if !isnumber(value) then
 		ErrorNoHaltWithStack("Expected a number, but was " .. type(value) .. "\n")

--- a/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
@@ -62,9 +62,6 @@ function PAM_EXTENSION:OnInitialize()
 	self:UpdateGamemodeMaps(engine.ActiveGamemode())
 end
 
-function PAM_EXTENSION
-
-
 function PAM_EXTENSION:RegisterOptions()
 	if PAM.vote_type ~= "map" then return end
 

--- a/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
@@ -46,9 +46,9 @@ function PAM_EXTENSION:UpdateGamemodeMaps(gamemode)
 	if (info) then
 		local info = util.KeyValuesToTable(info)
 		if (info.maps) then
-			self.gamemode_maps_pattern[gamemode] = info.maps
+			self.gamemode_maps_pattern[gamemode] = string.Split(info.maps, "|")
 		elseif (info.fretta_maps) then
-			self.gamemode_maps_pattern[gamemode] = table.concat(info.fretta_maps, "|")
+			self.gamemode_maps_pattern[gamemode] = info.fretta_maps
 		end
 	end
 end
@@ -60,6 +60,13 @@ end
 
 function PAM_EXTENSION:OnInitialize()
 	self:UpdateGamemodeMaps(engine.ActiveGamemode())
+end
+
+local function mapMatchesPattern(map, pattern)
+	for _, v in pairs(pattern) do
+		if string.match(map, v) then return true end
+	end
+	return false
 end
 
 function PAM_EXTENSION:RegisterOptions()
@@ -113,7 +120,7 @@ function PAM_EXTENSION:RegisterOptions()
 
 		if populate_from_info_setting:GetActiveValue() and
 				self.gamemode_maps_pattern[current_gamemode] and #self.gamemode_maps_pattern[current_gamemode] > 0 and
-				string.match(map, self.gamemode_maps_pattern[current_gamemode]) then
+				mapMatchesPattern(map, self.gamemode_maps_pattern[current_gamemode]) then
 			PAM.RegisterOption(map)
 			continue
 		end

--- a/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
@@ -52,7 +52,6 @@ function PAM_EXTENSION:RegisterOptions()
 				gamemode_maps_pattern = info.maps
 			end
 		end
-		print(gamemode_maps_pattern)
 	end
 
 	local prefixes = string.Split(prefixes_setting:GetActiveValue(), ",")

--- a/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
@@ -33,26 +33,26 @@ local function SetMapCooldown(mapname, cooldown)
 	end
 end
 
+function PAM_EXTENSION:OnInitialize()
+	local activeGamemode = engine.ActiveGamemode()
+	local info = file.Read("gamemodes/"..activeGamemode.."/"..activeGamemode..".txt", "GAME")
+
+	if (info) then
+		local info = util.KeyValuesToTable(info)
+		self.gamemode_maps_pattern = info.maps
+
+		if (!self.gamemode_maps_pattern and info.fretta_maps) then
+			self.gamemode_maps_pattern = table.concat(info.fretta_maps, "|")
+		end
+	end
+end
+
+
 function PAM_EXTENSION:RegisterOptions()
 	if PAM.vote_type ~= "map" then return end
 
 	local all_maps = file.Find("maps/*.bsp", "GAME")
 	local starting_option_count = PAM.option_count
-
-	local gamemode_maps_pattern
-	if populate_from_info_setting:GetActiveValue() then
-		local activeGamemode = engine.ActiveGamemode()
-		local info = file.Read("gamemodes/"..activeGamemode.."/"..activeGamemode..".txt", "GAME")
-
-		if (info) then
-			local info = util.KeyValuesToTable(info)
-			if (info.fretta_maps) then
-				gamemode_maps_pattern = table.concat(info.fretta_maps, "|")
-			else
-				gamemode_maps_pattern = info.maps
-			end
-		end
-	end
 
 	local prefixes = string.Split(prefixes_setting:GetActiveValue(), ",")
 	local blacklist = blacklist_setting:GetActiveValue()
@@ -89,13 +89,13 @@ function PAM_EXTENSION:RegisterOptions()
 			continue
 		end
 
-		if gamemode_maps_pattern and string.match(map, gamemode_maps_pattern) then
+		if populate_from_info_setting:GetActiveValue() and self.gamemode_maps_pattern and string.match(map, self.gamemode_maps_pattern) then
 			PAM.RegisterOption(map)
 			continue
 		end
 
 		-- add all maps when no prefix is selected
-		if not gamemode_maps_pattern and #prefixes == 0 then
+		if not (populate_from_info_setting:GetActiveValue() and self.gamemode_maps_pattern) and #prefixes == 0 then
 			PAM.RegisterOption(map)
 			continue;
 		end

--- a/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
@@ -78,6 +78,14 @@ function PAM_EXTENSION:RegisterOptions()
 	if #prefixes == 1 and prefixes[1] == "" then
 		prefixes[1] = nil
 	end
+	
+	-- Using the convar gamemode to get the active gamemode as the gamemode extension will change the gamemode convar
+	local current_gamemode = gamemode_name or GetConVar("gamemode"):GetString() or engine.ActiveGamemode()
+	
+	-- Somehow gamemode maps are not loaded, let's try loading them
+	if populate_from_info_setting:GetActiveValue() and not self.gamemode_maps_pattern[current_gamemode] then
+		self:UpdateGamemodeMaps(current_gamemode)
+	end
 
 	for _, map in RandomPairs(all_maps) do
 		map = map:sub(1, -5)
@@ -103,8 +111,6 @@ function PAM_EXTENSION:RegisterOptions()
 			continue
 		end
 
-		-- Using the convar gamemode to get the active gamemode as the gamemode extension will change the gamemode convar
-		local current_gamemode = GetConVar("gamemode"):GetString() or engine.ActiveGamemode()
 		if populate_from_info_setting:GetActiveValue() and
 				self.gamemode_maps_pattern[current_gamemode] and #self.gamemode_maps_pattern[current_gamemode] > 0 and
 				string.match(map, self.gamemode_maps_pattern[current_gamemode]) then

--- a/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
@@ -41,7 +41,6 @@ function PAM_EXTENSION:RegisterOptions()
 
 	local gamemode_maps_pattern
 	if populate_from_info_setting:GetActiveValue() then
-		print("Populating shit!")
 		local activeGamemode = engine.ActiveGamemode()
 		local info = file.Read("gamemodes/"..activeGamemode.."/"..activeGamemode..".txt", "GAME")
 

--- a/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/map_provider.lua
@@ -33,19 +33,36 @@ local function SetMapCooldown(mapname, cooldown)
 	end
 end
 
-function PAM_EXTENSION:OnInitialize()
-	local activeGamemode = engine.ActiveGamemode()
-	local info = file.Read("gamemodes/"..activeGamemode.."/"..activeGamemode..".txt", "GAME")
+-- Support per gamemode
+PAM_EXTENSION.gamemode_maps_pattern = {}
+function PAM_EXTENSION:UpdateGamemodeMaps(gamemode)
+	-- If the data has previously been loaded, don't load it again
+	if self.gamemode_maps_pattern[gamemode] then return end
 
+	local info = file.Read("gamemodes/"..gamemode.."/"..gamemode..".txt", "GAME")
+
+	-- Empty var, so even if it couldn't be loaded it's set
+	self.gamemode_maps_pattern[gamemode] = {}
 	if (info) then
 		local info = util.KeyValuesToTable(info)
-		self.gamemode_maps_pattern = info.maps
-
-		if (!self.gamemode_maps_pattern and info.fretta_maps) then
-			self.gamemode_maps_pattern = table.concat(info.fretta_maps, "|")
+		if (info.maps) then
+			self.gamemode_maps_pattern[gamemode] = info.maps
+		elseif (info.fretta_maps) then
+			self.gamemode_maps_pattern[gamemode] = table.concat(info.fretta_maps, "|")
 		end
 	end
 end
+
+function PAM_EXTENSION:OnGamemodeChanged(gamemode)
+	-- Load maps for new gamemode
+	self:UpdateGamemodeMaps(gamemode)
+end
+
+function PAM_EXTENSION:OnInitialize()
+	self:UpdateGamemodeMaps(engine.ActiveGamemode())
+end
+
+function PAM_EXTENSION
 
 
 function PAM_EXTENSION:RegisterOptions()
@@ -89,13 +106,18 @@ function PAM_EXTENSION:RegisterOptions()
 			continue
 		end
 
-		if populate_from_info_setting:GetActiveValue() and self.gamemode_maps_pattern and string.match(map, self.gamemode_maps_pattern) then
+		-- Using the convar gamemode to get the active gamemode as the gamemode extension will change the gamemode convar
+		local current_gamemode = GetConVar("gamemode"):GetString() or engine.ActiveGamemode()
+		if populate_from_info_setting:GetActiveValue() and
+				self.gamemode_maps_pattern[current_gamemode] and #self.gamemode_maps_pattern[current_gamemode] > 0 and
+				string.match(map, self.gamemode_maps_pattern[current_gamemode]) then
 			PAM.RegisterOption(map)
 			continue
 		end
 
 		-- add all maps when no prefix is selected
-		if not (populate_from_info_setting:GetActiveValue() and self.gamemode_maps_pattern) and #prefixes == 0 then
+		if not (populate_from_info_setting:GetActiveValue() and self.gamemode_maps_pattern[current_gamemode] and #self.gamemode_maps_pattern[current_gamemode] > 0)
+				and #prefixes == 0 then
 			PAM.RegisterOption(map)
 			continue;
 		end

--- a/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
@@ -7,10 +7,6 @@ function PAM_EXTENSION:Initialize()
 end
 
 function PAM_EXTENSION:OnInitialize()
-	-- terrortown support
-	if GAMEMODE_NAME ~= "terrortown" then return end
-
-
 	-- Notify PAM that the round has ended
 	hook.Add("TTTEndRound", "PAM_RoundEnded", function()
 		PAM.EndRound()

--- a/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
@@ -2,6 +2,10 @@ PAM_EXTENSION.name = "terrortown_support"
 PAM_EXTENSION.enabled = true
 
 function PAM_EXTENSION:Initialize()
+	-- terrortown support
+	if engine.ActiveGamemode() ~= "terrortown" then return false end
+end
+
 function PAM_EXTENSION:OnInitialize()
 	-- terrortown support
 	if GAMEMODE_NAME ~= "terrortown" then return end

--- a/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
@@ -1,7 +1,7 @@
 PAM_EXTENSION.name = "terrortown_support"
 PAM_EXTENSION.enabled = true
 
-function PAM_EXTENSION:Initialize()
+function PAM_EXTENSION:CanEnable()
 	-- terrortown support
 	if engine.ActiveGamemode() ~= "terrortown" then return false end
 end

--- a/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
@@ -6,13 +6,16 @@ function PAM_EXTENSION:CanEnable()
 	if engine.ActiveGamemode() ~= "terrortown" then return false end
 end
 
+local custom_round_counter_extension
 function PAM_EXTENSION:OnInitialize()
+	custom_round_counter_extension = PAM.extension_handler.GetExtension("custom_round_counter")
+
 	-- Notify PAM that the round has ended
 	hook.Add("TTTEndRound", "PAM_RoundEnded", function()
 		PAM.EndRound()
 	end)
 
-	local maxRounds = PAM.extension_handler.RunReturningEvent("GetRoundLimit")
+	local maxRounds = custom_round_counter_extension.enabled and custom_round_counter_extension.round_limit:GetActiveValue()
 	if maxRounds then
 		SetGlobalInt("ttt_rounds_left", maxRounds)
 	end

--- a/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
@@ -17,7 +17,9 @@ function PAM_EXTENSION:OnInitialize()
 
 	local maxRounds = custom_round_counter_extension.enabled and custom_round_counter_extension.round_limit:GetActiveValue()
 	if maxRounds then
-		SetGlobalInt("ttt_rounds_left", maxRounds)
+		hook.Add("TTTInitPostEntity", "PAM_SetRoundsLeft", function()
+			SetGlobalInt("ttt_rounds_left", maxRounds)
+		end)
 	end
 
 	-- ttt2/ttt2

--- a/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
@@ -12,6 +12,11 @@ function PAM_EXTENSION:OnInitialize()
 		PAM.EndRound()
 	end)
 
+	local maxRounds = PAM.extension_handler.RunReturningEvent("GetRoundLimit")
+	if maxRounds then
+		SetGlobalInt("ttt_rounds_left", maxRounds)
+	end
+
 	-- ttt2/ttt2
 	if TTT2 then
 		hook.Add("TTT2LoadNextMap", "PAM_Autostart_TTT2", function(nextmap, rounds_left, time_left)

--- a/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
+++ b/partly_adequate_mapvote/lua/pam/server/extensions/terrortown_support.lua
@@ -1,6 +1,7 @@
 PAM_EXTENSION.name = "terrortown_support"
 PAM_EXTENSION.enabled = true
 
+function PAM_EXTENSION:Initialize()
 function PAM_EXTENSION:OnInitialize()
 	-- terrortown support
 	if GAMEMODE_NAME ~= "terrortown" then return end

--- a/partly_adequate_mapvote/lua/pam/server/sv_pam.lua
+++ b/partly_adequate_mapvote/lua/pam/server/sv_pam.lua
@@ -1,10 +1,10 @@
 function PAM.Start(vote_type, vote_length_override, winner_callback_override)
 	if PAM.state ~= PAM.STATE_DISABLED then return end
 
-	PAM.vote_type = vote_type or "map"
-	PAM.winner_callback = winner_callback_override or PAM.ChangeMap
+	PAM.vote_type = vote_type or PAM.extension_handler.RunReturningEvent("GetDefaultVoteType") or "map"
+	PAM.winner_callback = winner_callback_override or PAM.type_callbacks[vote_type] or PAM.ChangeMap
 
-	local vote_length = vote_length_override or PAM.vote_length:GetActiveValue()
+	local vote_length = vote_length_override or PAM.extension_handler.RunReturningEvent("GetVoteLength", PAM.vote_type) or PAM.vote_length:GetActiveValue()
 
 	PAM.options = {}
 	PAM.votes = {}
@@ -81,6 +81,10 @@ function PAM.RegisterOption(option_name, option_win_callback)
 	end
 
 	PAM.options[PAM.option_count] = option
+end
+
+function PAM.RegisterTypeHandler(vote_type, winner_callback)
+	PAM.type_callbacks[vote_type] = winner_callback
 end
 
 function PAM.MakeOptionWin(option)

--- a/partly_adequate_mapvote/lua/pam/server/sv_pam.lua
+++ b/partly_adequate_mapvote/lua/pam/server/sv_pam.lua
@@ -2,7 +2,7 @@ function PAM.Start(vote_type, vote_length_override, winner_callback_override)
 	if PAM.state ~= PAM.STATE_DISABLED then return end
 
 	PAM.vote_type = vote_type or PAM.extension_handler.RunReturningEvent("GetDefaultVoteType") or "map"
-	PAM.winner_callback = winner_callback_override or PAM.type_callbacks[vote_type] or PAM.ChangeMap
+	PAM.winner_callback = winner_callback_override or PAM.type_callbacks[PAM.vote_type] or PAM.ChangeMap
 
 	local vote_length = vote_length_override or PAM.extension_handler.RunReturningEvent("GetVoteLength", PAM.vote_type) or PAM.vote_length:GetActiveValue()
 

--- a/partly_adequate_mapvote/lua/pam/sh_extension_handler.lua
+++ b/partly_adequate_mapvote/lua/pam/sh_extension_handler.lua
@@ -19,7 +19,7 @@ local function RegisterExtension()
 	extension.enabled = enabled_setting:GetActiveValue()
 
 	enabled_setting:AddCallback("extension handler", function(value)
-		extension.enabled = value
+		extension.enabled = (extension.CanEnable and extension:CanEnable() != false and value) or (!extension.CanEnable and value)
 
 		if value then
 			if extension.OnEnable then
@@ -35,8 +35,12 @@ local function RegisterExtension()
 	extension_indices[extension_name] = id
 
 	if extension.Initialize then
-		-- Initialize, and if returned false, we disable it
-		if extension:Initialize() == false then
+		extension:Initialize()
+	end
+
+	if extension.CanEnable then
+		-- Only disable if we return false, if nothing is returned we will assume it doesn't want to be turned off
+		if extension:CanEnable() == false then
 			extension.enabled = false
 		end
 	end

--- a/partly_adequate_mapvote/lua/pam/sh_extension_handler.lua
+++ b/partly_adequate_mapvote/lua/pam/sh_extension_handler.lua
@@ -25,9 +25,7 @@ local function RegisterExtension()
 			if extension.OnEnable then
 				extension:OnEnable()
 			end
-			return
-		end
-		if extension.OnDisable then
+		elseif extension.OnDisable then
 			extension:OnDisable()
 		end
 	end)
@@ -36,12 +34,15 @@ local function RegisterExtension()
 	PAM.extensions[id] = extension
 	extension_indices[extension_name] = id
 
-	if extension.enabled and extension.OnEnable then
-		extension:OnEnable()
+	if extension.Initialize then
+		-- Initialize, and if returned false, we disable it
+		if extension:Initialize() == false then
+			extension.enabled = false
+		end
 	end
 
-	if extension.Initialize then
-		extension:Initialize()
+	if extension.enabled and extension.OnEnable then
+		extension:OnEnable()
 	end
 
 	print("[PAM] Registered extension \"" .. extension_name .. "\" (" .. (extension.enabled and "enabled" or "disabled") .. ")")

--- a/partly_adequate_mapvote/lua/pam/sh_extension_handler.lua
+++ b/partly_adequate_mapvote/lua/pam/sh_extension_handler.lua
@@ -98,6 +98,15 @@ function PAM.extension_handler.RunAvalanchingEvent(event_name, combine, ...)
 	return combined_result
 end
 
+function PAM.extension_handler.GetExtension(name)
+	for i = 1, #PAM.extensions do
+		local extension = PAM.extensions[i]
+		if extension.name == name then
+			return extension
+		end
+	end
+end
+
 hook.Add("Initialize", "PAM_Initialize_Extensions", function()
 	PAM.extension_handler.RunEvent("OnInitialize")
 end)

--- a/partly_adequate_mapvote/lua/pam/sh_init.lua
+++ b/partly_adequate_mapvote/lua/pam/sh_init.lua
@@ -13,6 +13,9 @@ PAM.STATE_FINISHED = 2
 --the current state
 PAM.state = PAM.STATE_DISABLED
 
+-- vote type callbacks
+PAM.type_callbacks = {}
+
 --the voteable maps
 PAM.options = {}
 PAM.option_count = 0


### PR DESCRIPTION
I have started using this for a multi-gamemode server I have and it's great, with the exception that it's missing a few features or it needs a little more polish (mostly not on this repo, but the others, I will make PRs later).

For now the changes I've made are:
- `PAM_EXTENSION:Initialize()` runs first, and if `false` is returned by the extension, it will be disabled. The reason behind this is so extensions that depend on gamemodes, such as the terrotown one, get disabled if the current gamemode isn't terrortown, so if the extension has more hooks/functions, these don't get called when the gamemode is different.
- `custom_rounds_counter` exposes the "round_limit" setting via `GetRoundLimit`.
- `terrortown_support` now utilizes both of these, disabling itself if the gamemode is not terrortown, and setting the native rounds left counter match up with that in `custom_rounds_counter`, so whenever a round finishes the counter is accurate.
- Added a new setting to `map_provider`: `populate_from_info`, this setting will read the gamemode.txt file and look for two keys, `fretta_maps` and `maps`, and if found, it will apply this filter to the maps.